### PR TITLE
Update lightspeed-httpd-conf.j2

### DIFF
--- a/playbooks/templates/lightspeed-httpd-conf.j2
+++ b/playbooks/templates/lightspeed-httpd-conf.j2
@@ -31,7 +31,7 @@
 # same ServerRoot for multiple httpd daemons, you will need to change at
 # least PidFile.
 #
-ServerRoot "/etc/httpd"
+ServerRoot "/etc/httpdd"
 
 #
 # Listen: Allows you to bind Apache to specific IP addresses and/or
@@ -121,7 +121,7 @@ ServerAdmin root@localhost
 # documents. By default, all requests are taken from this directory, but
 # symbolic links and aliases may be used to point to other locations.
 #
-DocumentRoot "/var/www/htmll"
+DocumentRoot "/var/www/html"
 
 #
 # Relax access to content within /var/www.


### PR DESCRIPTION
moved error/typo from DocumentRoot to ServerRoot.  Better exercise/results for rhel lightspeed.