### PR TITLE
Update rhel10-unit-webconsole.yml to fix rpm deprecated in RHEL10

### DIFF
--- a/playbooks/rhel10-unit-webconsole.yml
+++ b/playbooks/rhel10-unit-webconsole.yml
@@ -28,9 +28,9 @@
   become: true
   tasks:
 
-    - name: "rhel10-unit-webconsole : dnf install additional packages"
+    - name: "rhel10-unit-webconsole : dnf install additional packages (pmlogger in particular)"
       ansible.builtin.dnf: 
-        name: cockpit-pcp
+        name: pcp
         state: installed
       register: result
       retries: 10


### PR DESCRIPTION
rpm package "cockpit-pcp" no longer exists for permantent metric collection in web console in RHEL 10.  Now "pmlogger" utility that is part of PCP does this, so updated rpm to install pcp and it will pull in related pre-reqs instead.