### PR TITLE
Update rhel10-prep.yml

### DIFF
--- a/playbooks/rhel10-prep.yml
+++ b/playbooks/rhel10-prep.yml
@@ -32,7 +32,7 @@
 
   - name: "rhel10-prep : PACKAGE install WANTED packages"
     dnf: 
-      name: tmux,policycoreutils-python-utils
+      name: tmux,policycoreutils-python-utils,nmap-ncat
       state: installed
     register: result
     retries: 10


### PR DESCRIPTION
added "nmap-ncat" rpm for bastion so "nc" command available as part of Leapp exercise