### PR TITLE
Update rhel10-unit-leapp.yml

### DIFF
--- a/playbooks/rhel10-unit-leapp.yml
+++ b/playbooks/rhel10-unit-leapp.yml
@@ -11,7 +11,10 @@
       retries: 10
       until: result is succeeded
       delay: 5
- 
+      
+    - name: Disable rhel 9 supplementary repo.  No rhel 10 supp on demo.RH sat server, breaks leapp
+      ansible.builtin.shell: /sbin/subscription-manager repos --disable=rhel-9-for-x86_64-supplementary-rpms 2>/dev/null
+
     - name: "rhel10-unit-leapp : calculate required /boot disk constipation factor"
       vars:
         target_percentage: 90


### PR DESCRIPTION
added section to leapp to remove rhel 9 supplementary repo.  no rhel 10 supp. on demo.RH sat server so breaks leapp