### PR TITLE
Update rhel10-unit-lightspeed.yml

### DIFF
--- a/playbooks/rhel10-unit-lightspeed.yml
+++ b/playbooks/rhel10-unit-lightspeed.yml
@@ -5,7 +5,7 @@
 
     - name: "rhel10-unit-lightspeed : dnf install packages"
       dnf: 
-        name:  command-line-assistant,httpd
+        name:  command-line-assistant,httpd,cjose
         state: installed
       register: result
       retries: 10


### PR DESCRIPTION
- added test rpm cjose to lightspeed / node2 to see if summit-2026 is the repo being used for hol-rhel-showroom