### PR TITLE
Update rhel10-unit-lightspeed.yml

### DIFF
--- a/playbooks/rhel10-unit-lightspeed.yml
+++ b/playbooks/rhel10-unit-lightspeed.yml
@@ -5,7 +5,7 @@
 
     - name: "rhel10-unit-lightspeed : dnf install packages"
       dnf: 
-        name:  command-line-assistant,httpd
+        name:  command-line-assistant,httpd,ed
         state: installed
       register: result
       retries: 10


### PR DESCRIPTION
- added "ed" rpm to track summit-2025 repo usage